### PR TITLE
Close existing pinned tabs.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -6,12 +6,20 @@ function onError(error) {
 }
 
 function openTabs(item) {
-    var pinned_websites = item.pinned_websites;
-    pinned_websites.forEach(function(website) {
-        browser.tabs.create({url: website, "pinned": true,
-            "active": false});
+    let getExistingPinnedTabs = browser.tabs.query({ "pinned": true });
+    getExistingPinnedTabs.then(
+        (existingPinnedTabs) => {
+            pinIds = existingPinnedTabs.map( tab => tab.id );
+            return browser.tabs.remove(pinIds);
+        }
+    ).then(() => {
+        var pinned_websites = item.pinned_websites;
+        pinned_websites.forEach(function(website) {
+            browser.tabs.create({url: website, "pinned": true,
+                "active": false});
+        });
+        opened_tabs = true;
     });
-    opened_tabs = true;
 }
 
 if (opened_tabs == false) {


### PR DESCRIPTION
If any pinned tabs exist, then remove them and open the persistent tabs. This solves issue #3, which was also brought up in the reviews.

I realize that this extension is for persisting tabs when history is auto-removed after the window is closed. This PR will not interfere with that behavior. I want to keep my history, but also fix the issue where I lose a session and then I have to reload all of my pinned tabs. 