### PR TITLE
Implement an option to keep pinned tabs in all open windows

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -32,7 +32,7 @@
         "description": "Label for slider which adds grab action to tab context menu"
     },
     "pinInAllWindowsSlider": {
-        "message": "Pin the websites in all opened windows",
+        "message": "Hefte die Tabs in allen Fenstern an",
         "description": "Label for slider which adds functionality to pin tabs in every window"
     },
     "syncSlider": {

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -31,6 +31,10 @@
         "message": "Füge \"Sammel' die aktuell angehefteten Tabs\" zum Tabkontextmenü hinzu",
         "description": "Label for slider which adds grab action to tab context menu"
     },
+    "pinInAllWindowsSlider": {
+        "message": "Pin the websites in all opened windows",
+        "description": "Label for slider which adds functionality to pin tabs in every window"
+    },
     "syncSlider": {
         "message": "Synchronisiere Einstellungen mit Firefox Sync (Opt-in auf jedem Gerät)",
         "description": "Label for slider which controls add-on sync"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -31,6 +31,10 @@
         "message": "Add \"Grab currently pinned tabs\" to tab context menu",
         "description": "Label for slider which adds grab action to tab context menu"
     },
+    "pinInAllWindowsSlider": {
+        "message": "Pin the websites in all opened windows",
+        "description": "Label for slider which adds functionality to pin tabs in every window"
+    },
     "syncSlider": {
         "message": "Synchronize settings with Firefox Sync (opt-in on every device)",
         "description": "Label for slider which controls add-on sync"

--- a/src/background.js
+++ b/src/background.js
@@ -1,28 +1,63 @@
 import { addMenuItem } from "./contextmenu.js";
 import { storage } from "./prefs.js";
 
-// only open on the inital startup
-var opened_tabs = false;
+// Flag to mark whether the initialization had run
+var initialized = false;
 
 function onError(error) {
     console.log(`Error: ${error}`);
 }
 
-function openTabs(item) {
+function openTabs(item, openInAll, newWindow) {
+    // Set the flag in the beginning, we don't want to wait for promises to resolve for initialization
+    initialized = true;
     let getExistingPinnedTabs = browser.tabs.query({ "pinned": true });
+
     getExistingPinnedTabs.then(
         (existingPinnedTabs) => {
-            let pinIds = existingPinnedTabs.map( tab => tab.id );
+            let tabs = existingPinnedTabs;
+            if (newWindow && newWindow.id) {
+                // Filter out tabs only from the current window
+                tabs = tabs.filter(tab => tab.windowId === newWindow.id);
+            }
+            let pinIds = tabs.map( tab => tab.id );
             return browser.tabs.remove(pinIds);
         }
     ).then(() => {
         let pinned_websites = item.pinned_websites;
-        pinned_websites.forEach(function(website) {
-            browser.tabs.create({url: website, "pinned": true,
-                "active": false});
+
+        // Resolve windowIds that will be targeted by new pins
+        new Promise((resolve) => {
+            if (typeof newWindow !== 'undefined') {
+                // We only want to pin tabs in the new window
+                resolve([newWindow.id]);
+                return;
+            }
+
+            if (openInAll) {
+                browser.windows.getAll().then(allWindows => {
+                    resolve(allWindows.map(currentWindow => currentWindow.id));
+                })
+                return;
+            } else {
+                // Resolve undefined to open it only in the current window
+                resolve([undefined]);
+                return;
+            }
+        }).then(windowIds => {
+            windowIds.forEach(windowId => {
+                pinned_websites.forEach(function(website) {
+                    browser.tabs.create({
+                        active: false,
+                        pinned: true,
+                        url: website,
+                        windowId,
+                    });
+                });
+            })
         });
-        opened_tabs = true;
     });
+
 }
 
 function setupMenuItem(item) {
@@ -31,10 +66,24 @@ function setupMenuItem(item) {
     }
 }
 
-
-if (opened_tabs == false) {
+function executeTabOpening(newWindow) {
     let getWebsites = storage.get_pinned_websites();
-    getWebsites.then(openTabs, onError);
+    let inAllWindows = storage.get_pin_in_all_windows().then(item => !!item.pin_in_all_windows);
+    getWebsites.then((item) => {
+        inAllWindows.then((openInAll) => {
+            if (!newWindow || openInAll === true) {
+                openTabs(item, openInAll, newWindow)
+            }
+        });
+    }, onError);
     let gettingContextMenu = storage.get_context_menu_item();
     gettingContextMenu.then(setupMenuItem, onError);
+}
+
+if (initialized == false) {
+    executeTabOpening();
+
+    browser.windows.onCreated.addListener((newWindow) => {
+        executeTabOpening(newWindow);
+    })
 }

--- a/src/options.html
+++ b/src/options.html
@@ -44,6 +44,13 @@
               </label>
         </div>
         <div class="btns">
+              <span class="switch-label" id="pinInAllWindowsSliderLabel">__MSG_pinInAllWindowsSlider__</span>
+              <label class="switch">
+                  <input type="checkbox" id="pinInAllWindowsSlider">
+                  <span class="slider"></span>
+              </label>
+        </div>
+        <div class="btns">
               <span class="switch-label" id="syncSliderLabel">__MSG_syncSlider__</span>
               <label class="switch">
                   <input type="checkbox" id="syncSlider">

--- a/src/options.js
+++ b/src/options.js
@@ -229,6 +229,11 @@ function syncSlider(event) {
     }
 }
 
+function pinInAllWindowsSlider() {
+    let settingPinInAllWindowsSlider = storage.set_pin_in_all_windows(!!this.checked);
+    settingPinInAllWindowsSlider.then(null, onError);
+}
+
 function onError(error) {
     console.log(`Error: ${error}`);
 }
@@ -245,6 +250,9 @@ function load() {
 
     let gettingContextMenu = storage.get_context_menu_item();
     gettingContextMenu.then(finishLoading2, onError);
+
+    let gettingPinInAllWindows = storage.get_pin_in_all_windows();
+    gettingPinInAllWindows.then(finishLoading4, onError);
 }
 
 function init() {
@@ -270,6 +278,8 @@ function init() {
     i18n(document.getElementById("contextMenuSliderLabel"), "contextMenuSlider");
     document.getElementById("syncSlider").addEventListener("change", syncSlider);
     i18n(document.getElementById("syncSliderLabel"), "syncSlider");
+    document.getElementById("pinInAllWindowsSlider").addEventListener("change", pinInAllWindowsSlider);
+    i18n(document.getElementById("pinInAllWindowsSliderLabel"), "pinInAllWindowsSlider");
 
     browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (message === "refresh") {
@@ -299,6 +309,10 @@ function finishLoading2(item) {
 
 function finishLoading3(item) {
     document.getElementById("syncSlider").checked = item;
+}
+
+function finishLoading4(item) {
+    document.getElementById("pinInAllWindowsSlider").checked = !!item.pin_in_all_windows;
 }
 
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -49,6 +49,25 @@ class Storage {
         }
     }
 
+    async get_pin_in_all_windows() {
+        let syncing = await this.get_syncing();
+        if (syncing) {
+            return browser.storage.sync.get("pin_in_all_windows");
+        } else {
+            return browser.storage.local.get("pin_in_all_windows");
+        }
+    }
+
+    async set_pin_in_all_windows(pin) {
+        let syncing = await this.get_syncing();
+
+        if (syncing) {
+            return browser.storage.sync.set({"pin_in_all_windows": !!pin});
+        } else {
+            return browser.storage.local.set({"pin_in_all_windows": !!pin});
+        }
+    }
+
     async get_context_menu_item() {
         let syncing = await this.get_syncing();
         if (syncing) {


### PR DESCRIPTION
Implementation of persistent pin across all open windows, resolves #9

I don't speak german, so a translation would be handy if this would ever be merged.

To be honest, I'm not sure why the "initialized", previously "opened_tabs" flag was there, I wasn't able to replicate the behaviour, where the background.js would ever execute more than once. But I kept it there to be safe.