### PR TITLE
add first basic support for container tabs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,9 @@
   "permissions": [
     "storage",
     "tabs",
-    "contextMenus"
+    "contextMenus",
+    "contextualIdentities",
+    "cookies"
   ],
 
   "default_locale": "en",

--- a/src/background.js
+++ b/src/background.js
@@ -46,11 +46,12 @@ function openTabs(item, openInAll, newWindow) {
             }
         }).then(windowIds => {
             windowIds.forEach(windowId => {
-                pinned_websites.forEach(function(website) {
+                pinned_websites.forEach(function(tab) {
                     browser.tabs.create({
                         active: false,
                         pinned: true,
-                        url: website,
+                        url: tab.url,
+                        cookieStoreId: tab.cookieStoreId,
                         windowId,
                     });
                 });


### PR DESCRIPTION
This adds first basic support for saving the container with the pinned tab, and opening the tabs in their correct containers.
It works correctly when using 'grab currently open containers', but doesn't allow setting the container when manually adding or editing.

Since this changes the format of the pinned_websites storage item, I'm not sure if this causes issues with sync if the addons aren't running in the same version.

It's not perfect, but it works well enough for me :)