### PR TITLE
Fix options handling

### DIFF
--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,50 @@
+{
+    "extensionDescription": {
+        "message": "Conserve les sites webs épinglés après un redémarrage.",
+        "description": "Description de l'extension"
+    },
+    "grabButton": {
+        "message": "Prendre les onglets épinglés actuellement",
+        "description": "Légende du bouton prendre"
+    },
+    "addButton": {
+        "message": "Ajouter",
+        "description": "Légende du bouton ajouter"
+    },
+    "editButton": {
+        "message": "Éditer",
+        "description": "Légende du bouton éditer"
+    },
+    "upButton": {
+        "message": "Haut",
+        "description": "Légende du bouton haut"
+    },
+    "downButton": {
+        "message": "Bas",
+        "description": "Légende du bouton bas"
+    },
+    "deleteButton": {
+        "message": "Supprimer",
+        "description": "Légende du bouton supprimer"
+    },
+    "contextMenuSlider": {
+        "message": "Ajouter \"Prendre les onglets épinglés actuellement\" au menu contextuel des onglets",
+        "description": "Légende de l'interrupteur pour ajouter l'action de prendre les onglets au menu contextuel"
+    },
+    "pinInAllWindowsSlider": {
+        "message": "Épingler les sites webs dans toutes les fenêtres",
+        "description": "Légende de l'interrupteur pour épingler les sites webs dans toutes les fenêtres"
+    },
+    "syncSlider": {
+        "message": "Synchroniser les paramètres dans Firefox Sync (à activer sur chaque appareil)",
+        "description": "Légende de l'interrupteur pour la synchronisation"
+    },
+    "emptyRow": {
+        "message": "Vide",
+        "description": "Ligne vide, affichée quand aucune entrée n'est disponible"
+    },
+    "websitesTableHeader": {
+        "message": "Sites webs",
+        "description": "En-tête du tableau des sites webs"
+    }
+}

--- a/src/options.js
+++ b/src/options.js
@@ -16,9 +16,13 @@ function select(event) {
         .forEach(function(element) {
             element.className = "";
         });
-    var targetEle = event.target;
-    selection = targetEle;
-    targetEle.parentNode.className = "selected";
+
+    // currentTarget makes sure to target the element the listener has been defined to. Here, you're sure to target the TR element
+    var targetEle = event.currentTarget;
+
+    // So your selection is the TD inside the TR
+    selection = targetEle.querySelector('td');
+    targetEle.className = "selected";
 }
 
 function renderTable(newSelection) {
@@ -157,6 +161,7 @@ function add(event) {
         });
     var tbody = document.getElementById("tbl-websites");
     var tr = document.createElement("tr");
+    var targetIndex = null;
     if (selection == null) {
         if (pinned_websites.length == 0) {
             tbody.removeChild(tbody.firstChild);
@@ -166,6 +171,7 @@ function add(event) {
     else {
         selection.parentNode.parentNode.insertBefore(tr,
             selection.parentNode.nextSibling);
+        targetIndex = parseInt(selection.id) + 1
     }
     tr.addEventListener("click", select);
     tr.className = "selected";
@@ -184,10 +190,10 @@ function add(event) {
                     renderTable(pinned_websites.length - 1);
                 }
                 else {
-                    pinned_websites.splice(parseInt(selection.id) + 1, 0,
+                    pinned_websites.splice(targetIndex, 0,
                         editField.value);
                     save();
-                    renderTable(parseInt(selection.id) + 1);
+                    renderTable(targetIndex);
                 }
             }
             else {


### PR DESCRIPTION
Fixed issue #13 and other issues

The click handler for selection didn't always target the right component, so the ID wasn't always set when needed, causing the edit to sometimes miss.

Second fix : The add process sometimes pushed the new website to the top, when selecting another row and selecting back the new row