### PR TITLE
Add reset-pinned-tab context menu item

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -11,6 +11,10 @@
         "message": "Reopen persistent pins",
         "description": "Reopen button caption"
     },
+    "resetButton": {
+        "message": "Reset pinned tab to saved URL",
+        "description": "Reset button caption, shown on a pinned tab's context menu when its URL matches a saved entry"
+    },
     "addButton": {
         "message": "Add",
         "description": "Add button caption"
@@ -38,6 +42,10 @@
     "reopenContextMenuSlider": {
         "message": "Add \"Reopen persistent pins\" to tab context menu",
         "description": "Label for slider which adds reopen action to tab context menu"
+    },
+    "resetContextMenuSlider": {
+        "message": "Add \"Reset pinned tab to saved URL\" to tab context menu",
+        "description": "Label for slider which adds reset-tab action to tab context menu"
     },
     "pinInAllWindowsSlider": {
         "message": "Pin the websites in all opened windows",

--- a/src/contextmenu.js
+++ b/src/contextmenu.js
@@ -13,6 +13,16 @@ const reopenMenuItemParams = {
     contexts: ["tab"]
 }
 
+const resetMenuItemParams = {
+    id: "reset_tab",
+    title: browser.i18n.getMessage("resetButton"),
+    contexts: ["tab"],
+    visible: false
+}
+
+let resetMenuItemExists = false;
+let resetShowToken = 0;
+
 function grabPins() {
     const pinned_tabs = browser.tabs.query({
         pinned: true
@@ -27,11 +37,30 @@ function grabPins() {
     });
 }
 
+async function isResetEligible(tab) {
+    if (!tab || !tab.pinned) {
+        return false;
+    }
+    const pinned_websites = await storage.get_pinned_websites();
+    return pinned_websites.includes(tab.url);
+}
+
+function resetTab(tab) {
+    storage.get_pinned_websites().then((pinned_websites) => {
+        const matchedUrl = pinned_websites.find((website) => website === tab.url);
+        if (!matchedUrl) {
+            return;
+        }
+        browser.tabs.update(tab.id, {url: matchedUrl, loadReplace: true}).then(null, onError);
+    });
+}
+
 export async function setupMenuItems() {
 
     await browser.contextMenus.removeAll();
     const grab_menu_item = await storage.get_grab_context_menu_item();
     const reopen_menu_item = await storage.get_reopen_context_menu_item();
+    const reset_menu_item = await storage.get_reset_context_menu_item();
 
     if (grab_menu_item) {
         browser.contextMenus.create(grabMenuItemParams, () => {
@@ -49,15 +78,44 @@ export async function setupMenuItems() {
         });
     }
 
-    if (! (grab_menu_item || reopen_menu_item)) {
+    resetMenuItemExists = false;
+    if (reset_menu_item) {
+        browser.contextMenus.create(resetMenuItemParams, () => {
+            if (browser.runtime.lastError) {
+                console.log(`Error creating reset menu item: ${browser.runtime.lastError}`);
+            } else {
+                resetMenuItemExists = true;
+            }
+        });
+    }
+}
+
+browser.contextMenus.onClicked.addListener((info, tab) => {
+    if (info.menuItemId === "grab_current") {
+        grabPins()
+    }
+    else if (info.menuItemId === "reopen") {
+        executeTabOpening()
+    }
+    else if (info.menuItemId === "reset_tab") {
+        resetTab(tab)
+    }
+});
+
+browser.contextMenus.onShown.addListener((info, tab) => {
+    if (!resetMenuItemExists) {
         return;
     }
-    browser.contextMenus.onClicked.addListener((info, _tab) => {
-        if (info.menuItemId === "grab_current") {
-            grabPins()
+    const token = ++resetShowToken;
+    isResetEligible(tab).then((eligible) => {
+        if (token !== resetShowToken) {
+            // A newer onShown fired while this lookup was in flight (e.g. the user
+            // right-clicked a different tab before this one resolved) — discard
+            // this stale result so it can't overwrite the currently-open menu.
+            return;
         }
-        else if (info.menuItemId === "reopen") {
-            executeTabOpening()
-        }
+        browser.contextMenus.update("reset_tab", {visible: eligible}).then(() => {
+            browser.contextMenus.refresh();
+        }, onError);
     });
-}
+});

--- a/src/options.html
+++ b/src/options.html
@@ -57,6 +57,13 @@
             </label>
         </div>
         <div class="btns">
+            <span class="switch-label" id="resetContextMenuSliderLabel" data-i18n="resetContextMenuSlider"></span>
+            <label class="switch">
+                <input type="checkbox" id="resetContextMenuSlider">
+                <span class="slider"></span>
+            </label>
+        </div>
+        <div class="btns">
               <span class="switch-label" id="pinInAllWindowsSliderLabel" data-i18n="pinInAllWindowsSlider"></span>
               <label class="switch">
                   <input type="checkbox" id="pinInAllWindowsSlider">

--- a/src/options.js
+++ b/src/options.js
@@ -211,6 +211,11 @@ async function reopenContextMenuSlider(_event) {
     await setupMenuItems();
 }
 
+async function resetContextMenuSlider(_event) {
+    await storage.set_reset_context_menu_item(!!this.checked);
+    await setupMenuItems();
+}
+
 async function syncSlider(_event) {
     await storage.set_syncing(!!this.checked);
 }
@@ -226,6 +231,8 @@ async function load() {
     document.getElementById("grabContextMenuSlider").checked = await storage.get_grab_context_menu_item()
 
     document.getElementById("reopenContextMenuSlider").checked = await storage.get_reopen_context_menu_item();
+
+    document.getElementById("resetContextMenuSlider").checked = await storage.get_reset_context_menu_item();
 
     document.getElementById("pinInAllWindowsSlider").checked = await storage.get_pin_in_all_windows();
 
@@ -255,6 +262,7 @@ async function init() {
     document.getElementById("btn-delete").addEventListener("click", delete_);
     document.getElementById("grabContextMenuSlider").addEventListener("change", grabContextMenuSlider);
     document.getElementById("reopenContextMenuSlider").addEventListener("change", reopenContextMenuSlider);
+    document.getElementById("resetContextMenuSlider").addEventListener("change", resetContextMenuSlider);
     document.getElementById("syncSlider").addEventListener("change", syncSlider);
     document.getElementById("pinInAllWindowsSlider").addEventListener("change", pinInAllWindowsSlider);
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -125,6 +125,30 @@ class Storage {
             browser.storage.local.set({"reopen_context_menu_item": value}).then(null, onError);
         }
     }
+
+    async get_reset_context_menu_item() {
+        let syncing = await this.get_syncing();
+        let p;
+        if (syncing) {
+            p = await browser.storage.sync.get("reset_context_menu_item");
+        } else {
+            p = await browser.storage.local.get("reset_context_menu_item");
+        }
+        if (!("reset_context_menu_item" in p)) {
+            return false;
+        } else {
+            return p.reset_context_menu_item;
+        }
+    }
+
+    async set_reset_context_menu_item(value) {
+        let syncing = await this.get_syncing();
+        if (syncing) {
+            browser.storage.sync.set({"reset_context_menu_item": value}).then(null, onError);
+        } else {
+            browser.storage.local.set({"reset_context_menu_item": value}).then(null, onError);
+        }
+    }
 }
 
 export var storage = new Storage();


### PR DESCRIPTION
## Summary
- Adds a "Reset pinned tab to saved URL" tab context-menu item, gated by a new options-page toggle, that snaps a drifted pinned tab back to its saved persistent-pin URL (`browser.tabs.update(..., {loadReplace: true})`).
- Visibility is computed per right-click via `contextMenus.onShown` (exact-match against `pinned_websites`), with a monotonic-token guard against a stale async result clobbering a newer right-click's menu.
- Fixes a pre-existing bug along the way: `onClicked`/`onShown` listeners were being re-registered on every options-page toggle (accumulating duplicates); both are now registered once at module scope.

## Test Plan
- [x] Syntax/JSON validation on all changed files (`node --check`, `python3 -m json.tool`) — passing
- [x] Per-task spec-compliance + code-quality review (4/4 approved) and a final whole-branch integration review (verdict: ready to merge)
- [ ] Manual walkthrough in Firefox per the plan (`.internal/plans/2026-07-20-reset-pinned-tab-plan.md`, Task 5): toggle on/off, exact-URL-match behavior, `loadReplace` back-button check, sync-on/off — not run yet, no browser available in the agent sandbox

## Known follow-up (non-blocking)
The final review flagged that `onClicked`/`onShown` are now registered per-module-instantiation, so the background page and the options page each get their own copy of the listeners — if the options page is left open, grab/reopen/reset actions can double-fire. This widens (doesn't introduce) a pre-existing architectural gap; worth a fast follow-up but doesn't block this PR.

Also noted, unrelated to this PR: `src/contextmenu.js` has a pre-existing trailing-space typo in `import ... from "./common.js "` predating this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)